### PR TITLE
print a hint message for user who want to unbind from vfio-pci

### DIFF
--- a/vfio-pci-bind.sh
+++ b/vfio-pci-bind.sh
@@ -185,6 +185,11 @@ fi
 
 printf "success...\n\n"
 echo "Device ${VD} at ${BDF} bound to vfio-pci"
+echo "[Hint] if you want to unbind ${BDF}, run follow comand to unbind ${BDF} from vfio-pci,"
+echo "       echo ${BDF} > /sys/bus/pci/drivers/vfio-pci/unbind"
+
+printf '\n'
+
 echo 'Devices listed in /sys/bus/pci/drivers/vfio-pci:'
 ls -l /sys/bus/pci/drivers/vfio-pci | egrep [[:xdigit:]]{4}:
 printf "\nls -l /dev/vfio/\n"


### PR DESCRIPTION
When bound is complete, a hint message is printed telling the user how to unbind the BDF from the vfio-pci driver.
